### PR TITLE
Fix button flickering on websocket reconnect

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -47,7 +47,9 @@ function createWs() {
         if (data.event === 'claims_update') {
             claims = data.data;
             console.log(data);
-            pageCheck();
+
+            // wait until the page is completely loaded for the first update
+            waitForElm('.disrep-actions-buttons').then(pageCheck);
         }
     }
     
@@ -59,9 +61,7 @@ function createWs() {
         if (currentPage != location.href)
         {
             currentPage = location.href;
-            waitForElm('.disrep-actions-buttons').then((elm) => {
-                pageCheck();
-            });
+            waitForElm('.disrep-actions-buttons').then(pageCheck);
         }
     }, 500);
     
@@ -135,12 +135,6 @@ function createWs() {
             }
         }
     }
-    
-    // when the page is COMPLETELY loaded
-    waitForElm('.disrep-actions-buttons').then((elm) => {
-        pageCheck();
-    });
-
 
 
     ws.onclose = function close() {


### PR DESCRIPTION
When the websocket disconnected and reconnected, the buttons flickered (quickly turned from gray/red to blue to gray/red again) since `pageCheck()` was called without waiting for the first `claims_udpate` from the server.

This was fixed by only calling `pageCheck()` on `claims_update`, and waiting for the page to be loaded for the first `claims_update` if the page was reloaded.
